### PR TITLE
fixed the review export not working -

### DIFF
--- a/app/code/community/Yotpo/Yotpo/Model/Export/Csv.php
+++ b/app/code/community/Yotpo/Yotpo/Model/Export/Csv.php
@@ -39,32 +39,6 @@ class Yotpo_Yotpo_Model_Export_Csv extends Mage_Core_Model_Abstract
             Mage::log($e->getMessage());
         }
     }
-    
-    
-    public function exportData($reviewsToExport)
-    {
-        try {
-            $storeId = Mage::app()->getStore()->getid();
-            $allReviews = Mage::getModel('review/review')
-                    ->getResourceCollection()
-                    ->addStoreFilter($storeId)
-                    ->addRateVotes();
-            $data = array();
-            foreach ($allReviews as $fullReview) {
-                # check if we want to export the current review
-                foreach ($reviewsToExport as $reviewId) {
-                    if ($fullReview->getId() == $reviewId) {
-                       $data = $this->writeReview($storeId, $fullReview);
-                       
-                        break;
-                    }
-                }
-            }
-            return $data;
-        } catch (Exception $e) {
-            Mage::log($e->getMessage());
-        }
-    }
 
     /**
      * Writes the head row with the column names in the csv file.

--- a/app/code/community/Yotpo/Yotpo/controllers/Review/ExportController.php
+++ b/app/code/community/Yotpo/Yotpo/controllers/Review/ExportController.php
@@ -8,8 +8,7 @@ class Yotpo_Yotpo_Review_ExportController extends Mage_Adminhtml_Controller_Acti
     {
         $reviews = $this->getRequest()->getPost('reviews', array());
         $file = Mage::getModel('Yotpo_Yotpo_Model_Export_Csv')->exportReviews($reviews);
-        $data = Mage::getModel('Yotpo_Yotpo_Model_Export_Csv')->exportData($reviews);
-        $this->_prepareDownloadResponse($file, array('type' => 'filename', 'value' => $data));
+        $this->_prepareDownloadResponse($file, file_get_contents(Mage::getBaseDir('export') . '/' . $file));
     }
     
     protected function _isAllowed()


### PR DESCRIPTION
a file is created, but then the data is regenerated and used to send to the user. However this is broken as the $data
variable in exportData only ever contains the last line of data. There is no need to generate it twice.

this change removes the exportData function and just reads the contents of the already created csv. The export now works properly.