### PR TITLE
Fix exception logging

### DIFF
--- a/app/code/community/Yotpo/Yotpo/Helper/RichSnippets.php
+++ b/app/code/community/Yotpo/Yotpo/Helper/RichSnippets.php
@@ -45,7 +45,7 @@ class Yotpo_Yotpo_Helper_RichSnippets extends Mage_Core_Helper_Abstract {
             }
             return array("average_score" => $snippet->getAverageScore(), "reviews_count" => $snippet->getReviewsCount());
         } catch (Exception $e) {
-            Mage::log($e);
+            Mage::logException($e);
         }
         return array();
     }


### PR DESCRIPTION
Logging an exception via `Mage::log` usually leads to an "allowed memory size exhausted" error, because the exception object is so big. Using `Mage::logException` is the correct and safe way to log an exception.